### PR TITLE
fix(ci): use configured publish secret aliases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -147,14 +147,14 @@ jobs:
         version: ${{ inputs.version }}
       env:
         PYPI_USERNAME: __token__
-        PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        PYPI_PASSWORD: ${{ env.PYPI_API_TOKEN }}
+        NODE_AUTH_TOKEN: ${{ env.NPM_TOKEN }}
         SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
         SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
         SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
         PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
         PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-        NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}
+        NUGET_PUBLISH_KEY: ${{ env.NUGET_PUBLISH_KEY }}
     - name: Publish SDKs (except Java)
       if: inputs.skipJavaSdk == true
       uses: pulumi/pulumi-package-publisher@3ec1409d3e894142b9825c7859be8e57d362762a # v0.0.23
@@ -163,12 +163,12 @@ jobs:
         version: ${{ inputs.version }}
       env:
         PYPI_USERNAME: __token__
-        PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        PYPI_PASSWORD: ${{ env.PYPI_API_TOKEN }}
+        NODE_AUTH_TOKEN: ${{ env.NPM_TOKEN }}
         SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
         SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
         SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
-        NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}
+        NUGET_PUBLISH_KEY: ${{ env.NUGET_PUBLISH_KEY }}
     - name: Download Go SDK
       uses: ./.github/actions/download-sdk
       with:


### PR DESCRIPTION
## Summary

- route npm, PyPI, and NuGet publisher credentials through the workflow-level environment aliases
- restore support for this repository's custom secret names (`CI_NPM_REGISTRY`, `PYPI_TOKEN`, and `NUGET_ORG_KEY`)
- unblock SDK publishing while pulumi-labs/ci-mgmt#20 carries the permanent generator fix

## Root cause

The generated publisher steps referenced fixed `secrets.NPM_TOKEN`, `secrets.PYPI_API_TOKEN`, and `secrets.NUGET_PUBLISH_KEY` names. This repository maps those credentials to different secret names at workflow scope, so the publisher received empty values and npm failed with `ENEEDAUTH`.

This intentionally patches an autogenerated workflow as a temporary unblock. A future `make ci-mgmt` will preserve the behavior after the upstream fix is merged and consumed.

## Verification

- `actionlint .github/workflows/publish.yml`
- `git diff --check`